### PR TITLE
2002-Refresh PR

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+    "name": "Azure CAF rover",
+ 
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    "dockerComposeFile": "docker-compose.yml",
+ 
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "rover",
+ 
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a volume mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/tf/caf",
+ 
+    // Use 'settings' to set *default* container specific settings.json values on container create. 
+    // You can edit these settings after create using File > Preferences > Settings > Remote.
+    "settings": { 
+        // If you are using an Alpine-based image, change this to /bin/ash
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+ 
+    // Uncomment the next line if you want start specific services in your Docker Compose config.
+    // "runServices": [],
+ 
+    // Uncomment this like if you want to keep your containers running after VS Code shuts down.
+    // "shutdownAction": "none",
+ 
+    // Uncomment the next line to run commands after the container is created.
+    "postCreateCommand": "cp -R /tmp/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/*",
+ 
+    // Add the IDs of extensions you want installed when the container is created in the array below.
+    "extensions": [
+        "4ops.terraform",
+        "mutantdino.resourcemonitor"
+    ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,29 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+ 
+  version: '3.7'
+  services:
+    rover:
+      image: aztfmod/rover:2002.2417
+    
+      labels:
+        - "caf=Azure CAF"
+   
+      volumes:
+        - ..:/tf/caf
+        - volume-caf-vscode:/home/vscode
+        - ~/.ssh:/tmp/.ssh-localhost:ro
+   
+        - /var/run/docker.sock:/var/run/docker.sock 
+   
+      # Overrides default command so things don't shut down after the process ends.
+      command: /bin/sh -c "while sleep 1000; do :; done" 
+   
+  volumes:
+     volume-caf-vscode:
+      labels:
+        - "caf=Azure CAF"
+
+  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.6 (February 25, 2020)
+
+BUG FIXES:
+
+* **Resource group:** CAF Classic not implementing prefix a per CAF recommendation ([#13](https://github.com/aztfmod/terraform-azurerm-caf-naming/pull/13))
+* **Resource group:** Trailing dash on CAF Classic and CAF random resource group is added at the end. ([#8](https://github.com/aztfmod/terraform-azurerm-caf-naming/issues/8))
+
 ## 0.1.2 (January 14, 2020)
 
 FEATURES:

--- a/examples/caf_naming_container_registry-cafrandom/locals.tf
+++ b/examples/caf_naming_container_registry-cafrandom/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_public_ip-cafrandom/locals.tf
+++ b/examples/caf_naming_public_ip-cafrandom/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_storage_account-cafclassic/locals.tf
+++ b/examples/caf_naming_storage_account-cafclassic/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_storage_account-cafrandom/locals.tf
+++ b/examples/caf_naming_storage_account-cafrandom/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_storage_account-passthrough/locals.tf
+++ b/examples/caf_naming_storage_account-passthrough/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_storage_account-random/locals.tf
+++ b/examples/caf_naming_storage_account-random/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_virtual_network-cafrandom/locals.tf
+++ b/examples/caf_naming_virtual_network-cafrandom/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_vm_linux-cafrandom/locals.tf
+++ b/examples/caf_naming_vm_linux-cafrandom/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/examples/caf_naming_vm_windows-random/locals.tf
+++ b/examples/caf_naming_vm_windows-random/locals.tf
@@ -5,7 +5,7 @@ locals {
     prefix = "test"
     resource_groups = {
         test = { 
-            name     = "test-caf"
+            name     = basename(abspath(path.module))
             location = "southeastasia" 
         },
     }

--- a/resourcegroup.tf
+++ b/resourcegroup.tf
@@ -3,8 +3,8 @@ locals {
   # Alphanumeric, period, hyphen, underscore.
     rg = {
       passthrough = (var.type == "rg" && var.convention == "passthrough") ? substr(local.filtered.alphanumhup, 0, local.max) : null
-      cafclassic  = (var.type == "rg" && var.convention == "cafclassic") ? substr("${lookup(var.caf_prefix, var.type)}-${local.filtered.alphanumhup}-${local.filteredpostfix.alphanumhup}", 0, local.max) : null 
-      cafrandom   = (var.type == "rg" && var.convention == "cafrandom") ? substr("${lookup(var.caf_prefix, var.type)}${local.filtered.alphanumhup}-${local.filteredpostfix.alphanumhup}${local.fullyrandom}", 0, local.max) : null 
+      cafclassic  = (var.type == "rg" && var.convention == "cafclassic") ? substr("${lookup(var.caf_prefix, var.type)}-${local.filtered.alphanumhup}${local.filteredpostfix.alphanumhup}", 0, local.max) : null 
+      cafrandom   = (var.type == "rg" && var.convention == "cafrandom") ? substr("${lookup(var.caf_prefix, var.type)}${local.filtered.alphanumhup}${local.filteredpostfix.alphanumhup}${local.fullyrandom}", 0, local.max) : null 
       random      = (var.type == "rg" && var.convention == "random") ? substr("${lookup(var.caf_prefix, var.type)}${local.fullyrandom}", 0, local.max) : null 
     }
 }


### PR DESCRIPTION
## 0.1.6 (February 25, 2020)

BUG FIXES:

* **Resource group:** CAF Classic not implementing prefix a per CAF recommendation ([#13](https://github.com/aztfmod/terraform-azurerm-caf-naming/pull/13))
* **Resource group:** Trailing dash on CAF Classic and CAF random resource group is added at the end. ([#8](https://github.com/aztfmod/terraform-azurerm-caf-naming/issues/8))
