### PR TITLE
Updating resource group rules to fix dash issues

### DIFF
--- a/examples/caf_naming_resource_group-cafclassic/README.md
+++ b/examples/caf_naming_resource_group-cafclassic/README.md
@@ -1,0 +1,3 @@
+# caf_naming_rg - cafclassic method
+
+Generates a resource group name using Cloud Adoption Framework naming convention module 

--- a/examples/caf_naming_resource_group-cafclassic/locals.tf
+++ b/examples/caf_naming_resource_group-cafclassic/locals.tf
@@ -1,0 +1,5 @@
+locals {
+    convention = "cafclassic"
+    name = "caftest"
+    prefix = "test"
+}

--- a/examples/caf_naming_resource_group-cafclassic/output.tf
+++ b/examples/caf_naming_resource_group-cafclassic/output.tf
@@ -1,0 +1,3 @@
+output "rg_name"{
+  value = module.caf_name_rg.rg
+}

--- a/examples/caf_naming_resource_group-cafclassic/rg.tf
+++ b/examples/caf_naming_resource_group-cafclassic/rg.tf
@@ -1,0 +1,7 @@
+module "caf_name_rg" {
+  source  = "../.."
+
+  name    = local.name
+  type    = "rg"
+  convention  = local.convention
+}

--- a/resourcegroup.tf
+++ b/resourcegroup.tf
@@ -3,8 +3,8 @@ locals {
   # Alphanumeric, period, hyphen, underscore.
     rg = {
       passthrough = (var.type == "rg" && var.convention == "passthrough") ? substr(local.filtered.alphanumhup, 0, local.max) : null
-      cafclassic  = (var.type == "rg" && var.convention == "cafclassic") ? substr("${lookup(var.caf_prefix, var.type)}-${local.filtered.alphanumhup}-${local.filteredpostfix.alphanumhup}", 0, local.max) : null 
-      cafrandom   = (var.type == "rg" && var.convention == "cafrandom") ? substr("${lookup(var.caf_prefix, var.type)}${local.filtered.alphanumhup}-${local.filteredpostfix.alphanumhup}${local.fullyrandom}", 0, local.max) : null 
+      cafclassic  = (var.type == "rg" && var.convention == "cafclassic") ? substr("${lookup(var.caf_prefix, var.type)}${local.filtered.alphanumhup}${var.postfix == "" ? "" : "-"}${local.filteredpostfix.alphanumhup}", 0, local.max) : null 
+      cafrandom   = (var.type == "rg" && var.convention == "cafrandom") ? substr("${lookup(var.caf_prefix, var.type)}${local.filtered.alphanumhup}${var.postfix == "" ? "" : "-"}${local.filteredpostfix.alphanumhup}${local.fullyrandom}", 0, local.max) : null 
       random      = (var.type == "rg" && var.convention == "random") ? substr("${lookup(var.caf_prefix, var.type)}${local.fullyrandom}", 0, local.max) : null 
     }
 }


### PR DESCRIPTION
The latest code was adding a double dash.
Also if the caller does not enter a postfix value it does not add a 2nd dash when using the cafclassic mode.
Also wrote some basic cafclassic examples for my own testing.